### PR TITLE
#165538154 Migrate signup endpoint to use database

### DIFF
--- a/SERVER/models/migrations/db.js
+++ b/SERVER/models/migrations/db.js
@@ -1,0 +1,27 @@
+import 'dotenv/config';
+import '@babel/polyfill';
+import { Pool } from 'pg';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export default {
+  /**
+   * DB Query
+   * @param {string} text
+   * @param {object} params
+   * @returns {promise} object
+   */
+  query(text, params) {
+    return new Promise((resolve, reject) => {
+      pool.query(text, params)
+        .then((res) => {
+          resolve(res);
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    });
+  },
+};

--- a/SERVER/models/migrations/queries.js
+++ b/SERVER/models/migrations/queries.js
@@ -1,0 +1,3 @@
+// export default {
+//   insert
+// }

--- a/SERVER/models/users.js
+++ b/SERVER/models/users.js
@@ -1,4 +1,4 @@
-import users from './mock_data/users';
+import db from './migrations/db';
 import helper from '../helpers/helper';
 
 /**
@@ -11,17 +11,16 @@ class User {
    * @method create()
    * @returns {object} New User informations
    */
-  static create(data) {
-    const newUser = {
-      id: users.length + 1,
-      firstName: data.firstName,
-      lastName: data.lastName,
-      email: data.email,
-      password: helper.hashPassword(data.password),
-      type: 'client',
-    };
-    users.push(newUser);
-    return newUser;
+  static async signUp(data) {
+    const queryText = `INSERT INTO users (firstname, lastname, email, password) VALUES ($1, $2, $3, $4) RETURNING *;`;
+    const {
+      firstName, lastName, email, password,
+    } = data;
+
+    const hashedPassword = helper.hashPassword(password);
+    const values = [firstName, lastName, email, hashedPassword];
+    const response = await db.query(queryText, values);
+    return response;
   }
 }
 


### PR DESCRIPTION

#### What does this PR do?
refactor signup endpoint to use database
#### Description of Task to be completed?
Refactored signup to work with a database instead of data structures:
When a user signs up, the details should now be stored in a  database instead of data structures.
#### How should this be manually tested?
clone the repo and cd into the file and run _'npm run start'_ in your command line.
And Use Postman to make POST req to localhost:3000/api/v1/auth/signup
#### Any background context you want to provide?
Null
#### What are the relevant pivotal tracker stories?
#165538154
#### Screenshots (if appropriate)
Null
#### Questions:
Null